### PR TITLE
Topic permissions

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -5,14 +5,25 @@ ifeq ($(.DEFAULT_GOAL),)
 .DEFAULT_GOAL = all
 endif
 
-# Automatically add rabbitmq-common to the dependencies, at least for
-# the Makefiles.
-ifneq ($(PROJECT),rabbit_common)
-ifneq ($(PROJECT),rabbitmq_public_umbrella)
-ifeq ($(filter rabbit_common,$(DEPS)),)
-DEPS += rabbit_common
-endif
-endif
+# PROJECT_VERSION defaults to:
+#   1. the version exported by rabbitmq-server-release;
+#   2. the version stored in `git-revisions.txt`, if it exists;
+#   3. a version based on git-describe(1), if it is a Git clone;
+#   4. 0.0.0
+
+PROJECT_VERSION := $(RABBITMQ_VERSION)
+
+ifeq ($(PROJECT_VERSION),)
+PROJECT_VERSION := $(shell \
+if test -f git-revisions.txt; then \
+	head -n1 git-revisions.txt | \
+	awk '{print $$$(words $(PROJECT_DESCRIPTION) version);}'; \
+else \
+	(git describe --dirty --abbrev=7 --tags --always --first-parent \
+	 2>/dev/null || echo rabbitmq_v0_0_0) | \
+	sed -e 's/^rabbitmq_v//' -e 's/^v//' -e 's/_/./g' -e 's/-/+/' \
+	 -e 's/-/./g'; \
+fi)
 endif
 
 # --------------------------------------------------------------------
@@ -27,24 +38,34 @@ endif
 # base of the topic branch.
 
 dep_amqp_client                       = git_rmq rabbitmq-erlang-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_amqp10_client                     = git_rmq rabbitmq-amqp1.0-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_amqp10_common                     = git_rmq rabbitmq-amqp1.0-common $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbit                            = git_rmq rabbitmq-server $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbit_common                     = git_rmq rabbitmq-common $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_amqp1_0                  = git_rmq rabbitmq-amqp1.0 $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_auth_backend_amqp        = git_rmq rabbitmq-auth-backend-amqp $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_auth_backend_cache       = git_rmq rabbitmq-auth-backend-cache $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_auth_backend_http        = git_rmq rabbitmq-auth-backend-http $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_auth_backend_ldap        = git_rmq rabbitmq-auth-backend-ldap $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_auth_mechanism_ssl       = git_rmq rabbitmq-auth-mechanism-ssl $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_aws                      = git_rmq rabbitmq-aws $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_boot_steps_visualiser    = git_rmq rabbitmq-boot-steps-visualiser $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_clusterer                = git_rmq rabbitmq-clusterer $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_cli                      = git_rmq rabbitmq-cli $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_codegen                  = git_rmq rabbitmq-codegen $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_consistent_hash_exchange = git_rmq rabbitmq-consistent-hash-exchange $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_ct_client_helpers        = git_rmq rabbitmq-ct-client-helpers $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_ct_helpers               = git_rmq rabbitmq-ct-helpers $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_delayed_message_exchange = git_rmq rabbitmq-delayed-message-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_dotnet_client            = git_rmq rabbitmq-dotnet-client $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_event_exchange           = git_rmq rabbitmq-event-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_federation               = git_rmq rabbitmq-federation $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_federation_management    = git_rmq rabbitmq-federation-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_java_client              = git_rmq rabbitmq-java-client $(current_rmq_ref) $(base_rmq_ref) master
-dep_rabbitmq_lvc                      = git_rmq rabbitmq-lvc-plugin $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_jms_client               = git_rmq rabbitmq-jms-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_jms_cts                  = git_rmq rabbitmq-jms-cts $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_jms_topic_exchange       = git_rmq rabbitmq-jms-topic-exchange $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_lvc_exchange             = git_rmq rabbitmq-lvc-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management               = git_rmq rabbitmq-management $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management_agent         = git_rmq rabbitmq-management-agent $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_management_exchange      = git_rmq rabbitmq-management-exchange $(current_rmq_ref) $(base_rmq_ref) master
@@ -53,8 +74,17 @@ dep_rabbitmq_management_visualiser    = git_rmq rabbitmq-management-visualiser $
 dep_rabbitmq_message_timestamp        = git_rmq rabbitmq-message-timestamp $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_metronome                = git_rmq rabbitmq-metronome $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_mqtt                     = git_rmq rabbitmq-mqtt $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_objc_client              = git_rmq rabbitmq-objc-client $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_peer_discovery_aws       = git_rmq rabbitmq-peer-discovery-aws $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_peer_discovery_common    = git_rmq rabbitmq-peer-discovery-common $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_peer_discovery_consul    = git_rmq rabbitmq-peer-discovery-consul $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_peer_discovery_etcd      = git_rmq rabbitmq-peer-discovery-etcd $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_peer_discovery_k8s       = git_rmq rabbitmq-peer-discovery-k8s $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_random_exchange          = git_rmq rabbitmq-random-exchange $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_recent_history_exchange  = git_rmq rabbitmq-recent-history-exchange $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_routing_node_stamp       = git_rmq rabbitmq-routing-node-stamp $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_rtopic_exchange          = git_rmq rabbitmq-rtopic-exchange $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_server_release           = git_rmq rabbitmq-server-release $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_sharding                 = git_rmq rabbitmq-sharding $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_shovel                   = git_rmq rabbitmq-shovel $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_shovel_management        = git_rmq rabbitmq-shovel-management $(current_rmq_ref) $(base_rmq_ref) master
@@ -62,42 +92,63 @@ dep_rabbitmq_stomp                    = git_rmq rabbitmq-stomp $(current_rmq_ref
 dep_rabbitmq_toke                     = git_rmq rabbitmq-toke $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_top                      = git_rmq rabbitmq-top $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_tracing                  = git_rmq rabbitmq-tracing $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_trust_store              = git_rmq rabbitmq-trust-store $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_test                     = git_rmq rabbitmq-test $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_dispatch             = git_rmq rabbitmq-web-dispatch $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_stomp                = git_rmq rabbitmq-web-stomp $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_web_stomp_examples       = git_rmq rabbitmq-web-stomp-examples $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_web_mqtt                 = git_rmq rabbitmq-web-mqtt $(current_rmq_ref) $(base_rmq_ref) master
+dep_rabbitmq_web_mqtt_examples        = git_rmq rabbitmq-web-mqtt-examples $(current_rmq_ref) $(base_rmq_ref) master
 dep_rabbitmq_website                  = git_rmq rabbitmq-website $(current_rmq_ref) $(base_rmq_ref) live master
-dep_sockjs                            = git_rmq sockjs-erlang $(current_rmq_ref) $(base_rmq_ref) master
 dep_toke                              = git_rmq toke $(current_rmq_ref) $(base_rmq_ref) master
 
 dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(current_rmq_ref) $(base_rmq_ref) master
 
-# FIXME: As of 2015-11-20, we depend on Ranch 1.2.1, but erlang.mk
-# defaults to Ranch 1.1.0. All projects depending indirectly on Ranch
-# needs to add "ranch" as a BUILD_DEPS. The list of projects needing
-# this workaround are:
-#     o  rabbitmq-web-stomp
-dep_ranch = git https://github.com/ninenines/ranch 1.2.1
+# Third-party dependencies version pinning.
+#
+# We do that in this file, which is copied in all projects, to ensure
+# all projects use the same versions. It avoids conflicts and makes it
+# possible to work with rabbitmq-public-umbrella.
+
+dep_cowboy = hex 2.0.0
+dep_cowlib = hex 2.0.0
+dep_jsx = hex 2.8.2
+dep_lager = hex 3.5.1
+dep_ranch = hex 1.4.0
+dep_ranch_proxy_protocol = hex 1.4.4
+dep_recon = hex 2.3.2
+
+dep_sockjs = git https://github.com/rabbitmq/sockjs-erlang.git 405990ea62353d98d36dbf5e1e64942d9b0a1daf
 
 RABBITMQ_COMPONENTS = amqp_client \
+		      amqp10_common \
+		      amqp10_client \
 		      rabbit \
 		      rabbit_common \
 		      rabbitmq_amqp1_0 \
 		      rabbitmq_auth_backend_amqp \
+		      rabbitmq_auth_backend_cache \
 		      rabbitmq_auth_backend_http \
 		      rabbitmq_auth_backend_ldap \
 		      rabbitmq_auth_mechanism_ssl \
+		      rabbitmq_aws \
 		      rabbitmq_boot_steps_visualiser \
 		      rabbitmq_clusterer \
+		      rabbitmq_cli \
 		      rabbitmq_codegen \
 		      rabbitmq_consistent_hash_exchange \
+		      rabbitmq_ct_client_helpers \
+		      rabbitmq_ct_helpers \
 		      rabbitmq_delayed_message_exchange \
 		      rabbitmq_dotnet_client \
 		      rabbitmq_event_exchange \
 		      rabbitmq_federation \
 		      rabbitmq_federation_management \
 		      rabbitmq_java_client \
-		      rabbitmq_lvc \
+		      rabbitmq_jms_client \
+		      rabbitmq_jms_cts \
+		      rabbitmq_jms_topic_exchange \
+		      rabbitmq_lvc_exchange \
 		      rabbitmq_management \
 		      rabbitmq_management_agent \
 		      rabbitmq_management_exchange \
@@ -106,17 +157,28 @@ RABBITMQ_COMPONENTS = amqp_client \
 		      rabbitmq_message_timestamp \
 		      rabbitmq_metronome \
 		      rabbitmq_mqtt \
+		      rabbitmq_objc_client \
+		      rabbitmq_peer_discovery_aws \
+		      rabbitmq_peer_discovery_common \
+		      rabbitmq_peer_discovery_consul \
+		      rabbitmq_peer_discovery_etcd \
+		      rabbitmq_peer_discovery_k8s \
+		      rabbitmq_random_exchange \
 		      rabbitmq_recent_history_exchange \
+		      rabbitmq_routing_node_stamp \
 		      rabbitmq_rtopic_exchange \
+		      rabbitmq_server_release \
 		      rabbitmq_sharding \
 		      rabbitmq_shovel \
 		      rabbitmq_shovel_management \
 		      rabbitmq_stomp \
-		      rabbitmq_test \
 		      rabbitmq_toke \
 		      rabbitmq_top \
 		      rabbitmq_tracing \
+		      rabbitmq_trust_store \
 		      rabbitmq_web_dispatch \
+		      rabbitmq_web_mqtt \
+		      rabbitmq_web_mqtt_examples \
 		      rabbitmq_web_stomp \
 		      rabbitmq_web_stomp_examples \
 		      rabbitmq_website
@@ -129,7 +191,7 @@ NO_AUTOPATCH += $(RABBITMQ_COMPONENTS)
 ifeq ($(origin current_rmq_ref),undefined)
 ifneq ($(wildcard .git),)
 current_rmq_ref := $(shell (\
-	ref=$$(git branch --list | awk '/^\* \(.*detached / {ref=$$0; sub(/.*detached [^ ]+ /, "", ref); sub(/\)$$/, "", ref); print ref; exit;} /^\* / {ref=$$0; sub(/^\* /, "", ref); print ref; exit}');\
+	ref=$$(LANG=C git branch --list | awk '/^\* \(.*detached / {ref=$$0; sub(/.*detached [^ ]+ /, "", ref); sub(/\)$$/, "", ref); print ref; exit;} /^\* / {ref=$$0; sub(/^\* /, "", ref); print ref; exit}');\
 	if test "$$(git rev-parse --short HEAD)" != "$$ref"; then echo "$$ref"; fi))
 else
 current_rmq_ref := master
@@ -139,11 +201,17 @@ export current_rmq_ref
 
 ifeq ($(origin base_rmq_ref),undefined)
 ifneq ($(wildcard .git),)
+possible_base_rmq_ref := v3.7.x
+ifeq ($(possible_base_rmq_ref),$(current_rmq_ref))
+base_rmq_ref := $(current_rmq_ref)
+else
 base_rmq_ref := $(shell \
-	(git rev-parse --verify -q stable >/dev/null && \
-	  git merge-base --is-ancestor $$(git merge-base master HEAD) stable && \
-	  echo stable) || \
+	(git rev-parse --verify -q master >/dev/null && \
+	 git rev-parse --verify -q $(possible_base_rmq_ref) >/dev/null && \
+	 git merge-base --is-ancestor $$(git merge-base master HEAD) $(possible_base_rmq_ref) && \
+	 echo $(possible_base_rmq_ref)) || \
 	echo master)
+endif
 else
 base_rmq_ref := master
 endif
@@ -233,57 +301,8 @@ prepare-dist::
 	@:
 
 # --------------------------------------------------------------------
-# Run a RabbitMQ node (moved from rabbitmq-run.mk as a workaround).
-# --------------------------------------------------------------------
-
-# Add "rabbit" to the build dependencies when the user wants to start
-# a broker or to the test dependencies when the user wants to test a
-# project.
-#
-# NOTE: This should belong to rabbitmq-run.mk. Unfortunately, it is
-# loaded *after* erlang.mk which is too late to add a dependency. That's
-# why rabbitmq-components.mk knows the list of targets which start a
-# broker and add "rabbit" to the dependencies in this case.
-
-ifneq ($(PROJECT),rabbit)
-ifeq ($(filter rabbit,$(DEPS) $(BUILD_DEPS)),)
-RUN_RMQ_TARGETS = run-broker \
-		  run-background-broker \
-		  run-node \
-		  run-background-node \
-		  start-background-node
-
-ifneq ($(filter $(RUN_RMQ_TARGETS),$(MAKECMDGOALS)),)
-BUILD_DEPS += rabbit
-endif
-endif
-
-ifeq ($(filter rabbit,$(DEPS) $(BUILD_DEPS) $(TEST_DEPS)),)
-ifneq ($(filter check tests tests-with-broker test,$(MAKECMDGOALS)),)
-TEST_DEPS += rabbit
-endif
-endif
-endif
-
-ifeq ($(filter rabbit_public_umbrella amqp_client rabbit_common rabbitmq_test,$(PROJECT)),)
-ifeq ($(filter rabbitmq_test,$(DEPS) $(BUILD_DEPS) $(TEST_DEPS)),)
-TEST_DEPS += rabbitmq_test
-endif
-endif
-
-# --------------------------------------------------------------------
 # rabbitmq-components.mk checks.
 # --------------------------------------------------------------------
-
-ifeq ($(PROJECT),rabbit_common)
-else ifdef SKIP_RMQCOMP_CHECK
-else ifeq ($(IS_DEP),1)
-else ifneq ($(filter co up,$(MAKECMDGOALS)),)
-else
-# In all other cases, rabbitmq-components.mk must be in sync.
-deps:: check-rabbitmq-components.mk
-fetch-deps: check-rabbitmq-components.mk
-endif
 
 # If this project is under the Umbrella project, we override $(DEPS_DIR)
 # to point to the Umbrella's one. We also disable `make distclean` so
@@ -298,11 +317,6 @@ endif
 ifeq ($(UNDER_UMBRELLA),1)
 ifneq ($(PROJECT),rabbitmq_public_umbrella)
 DEPS_DIR ?= $(abspath ..)
-
-distclean:: distclean-components
-	@:
-
-distclean-components:
 endif
 
 ifneq ($(filter distclean distclean-deps,$(MAKECMDGOALS)),)
@@ -312,11 +326,16 @@ endif
 
 UPSTREAM_RMQ_COMPONENTS_MK = $(DEPS_DIR)/rabbit_common/mk/rabbitmq-components.mk
 
+ifeq ($(PROJECT),rabbit_common)
+check-rabbitmq-components.mk:
+	@:
+else
 check-rabbitmq-components.mk:
 	$(verbose) cmp -s rabbitmq-components.mk \
 		$(UPSTREAM_RMQ_COMPONENTS_MK) || \
 		(echo "error: rabbitmq-components.mk must be updated!" 1>&2; \
 		  false)
+endif
 
 ifeq ($(PROJECT),rabbit_common)
 rabbitmq-components-mk:

--- a/src/rabbit_auth_backend_ip_range.erl
+++ b/src/rabbit_auth_backend_ip_range.erl
@@ -18,7 +18,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -export([description/0]).
--export([user_login_authorization/1, check_vhost_access/3, check_resource_access/3]).
+-export([user_login_authorization/1, check_vhost_access/3, check_resource_access/3, check_topic_access/4]).
 
 description() ->
     [{name, <<"IP_Range">>},
@@ -66,6 +66,8 @@ check_masks(Address, Masks) ->
     end.
 
 check_resource_access(#auth_user{}, #resource{}, _Permission) -> true.
+
+check_topic_access(#auth_user{}, #resource{}, _Permission, _Context) -> true.
 
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #4
Add a missing `rabbit_authz_backend` callback for topic permissions. The callback does not check anything, just like the `check_resource_access` callback.

Update `rabbitmq-components.mk`.