### PR TITLE
Allow "unknown" atom for address

### DIFF
--- a/src/rabbit_auth_backend_ip_range.erl
+++ b/src/rabbit_auth_backend_ip_range.erl
@@ -48,6 +48,7 @@ check_vhost_access(#auth_user{tags = Tags}, _VHostPath, AuthzData) ->
     end.
 
 check_masks(undefined, _Masks) -> true; % allow internal access
+check_masks(unknown, _Masks) -> true; % allow internal access
 check_masks(Address, Masks) ->
     R = lists:foldl(
         fun(StrMask, false) ->
@@ -84,6 +85,8 @@ env(F) ->
 
 extract_address(undefined) ->
     undefined;
+extract_address(unknown) ->
+    unknown;
 extract_address(#{peeraddr := Address}) ->
     Address.
 


### PR DESCRIPTION
When an `amqp_direct_connection` is established, `peer_host` is set to `unknown` in the adapter info. Take this into account here.

Fixes #18

To test:

* Run RabbitMQ from `master` using this `rabbitmq_management` and this plugin and the following config:

```
[
    {rabbit, [
        {log, [
            {console, [{enabled, true}, %% log.console
                       {level, debug}   %% log.console.level
            ]}
        ]},
        {auth_backends, [
            {rabbit_auth_backend_internal, [rabbit_auth_backend_internal, rabbit_auth_backend_ip_range]}
        ]}
    ]},
    {rabbitmq_auth_backend_ip_range, [
        {tag_masks, [
            {'administrator', [<<"::FFFF:127.0.0.0/24">>]},
            {'management', [<<"::FFFF:192.168.1.0/24">>]}
        ]},
        {default_masks, [<<"::0/0">>]}
    ]}
].
```

* From the management interface, create a queue and publish to it from the web UI. You will see a 500 error, and the log will show what is reported in #18 